### PR TITLE
fix: Revert Prometheus datasource URL back to container name

### DIFF
--- a/grafana-provisioning/datasources/datasources.yaml
+++ b/grafana-provisioning/datasources/datasources.yaml
@@ -3,5 +3,5 @@ apiVersion: 1
 datasources:
   - name: Prometheus
     type: prometheus
-    url: http://localhost:9090
+    url: http://prometheus:9090
     access: proxy


### PR DESCRIPTION
fix hostname datasource